### PR TITLE
Added class name of Toolkit class to introduction

### DIFF
--- a/doc/Algorithms/several-often-used-algorithms-on-graphs.md
+++ b/doc/Algorithms/several-often-used-algorithms-on-graphs.md
@@ -6,7 +6,7 @@ permalink: /doc/Algorithms/Several-often-used-algorithms-on-graphs/
 redirect_from: /doc/Algorithms/Several-often-used-algorithms-on-graphs_1.0/
 ---
 
-This class contains a lot of very small algorithms that could be often useful
+The class ``org.graphstream.algorithm.Toolkit`` contains a lot of very small algorithms that could be often useful
 with a graph. Most methods take a graph as first argument.
 
 


### PR DESCRIPTION
On the whole page, the class name Toolkit just appears once in the end. Naming it in the beginning makes it easier for the reader to find out, how he/she can use it.

I spend several minutes trying to find out, how I can use all these nice methods, until I found the example in the end.
