### PR TITLE
Add a missing bracket

### DIFF
--- a/doc/Tutorials/graph-visualisation.md
+++ b/doc/Tutorials/graph-visualisation.md
@@ -260,7 +260,7 @@ node#A {
 }
 ```
 
-![First stylesheet]({{ site.content_img }}/firstStyleSheet.png
+![First stylesheet]({{ site.content_img }}/firstStyleSheet.png)
 
 Note that the semi-colon is mandatory, even if there is only one property.
 


### PR DESCRIPTION
After this paragraph a bracket was missing to include the picture to illustrate the css mentioned below.

``` css
node#A {
    shape: box;
    size: 15px, 20px;
    fill-mode: plain;   /* Default.          */
    fill-color: red;    /* Default is black. */
    stroke-mode: plain; /* Default is none.  */
    stroke-color: blue; /* Default is black. */
}
```
